### PR TITLE
Cluster settings fixes

### DIFF
--- a/backend/elasticsurgery/utils/log.py
+++ b/backend/elasticsurgery/utils/log.py
@@ -6,7 +6,7 @@ from elasticsurgery.utils.elastic import get_state_es_client
 
 def create_log(type_, data):
     es_client = get_state_es_client()
-    es_client.create(
+    es_client.index(
         index=ES_LOGS_INDEX_NAME,
         body={
             'type': type_,

--- a/frontend/src/SettingsDashboard.jsx
+++ b/frontend/src/SettingsDashboard.jsx
@@ -216,6 +216,14 @@ class SettingsDashboard extends React.Component {
         this.props.putSetting(settingType, setting, value);
     };
 
+    renderAnyPutError() {
+        const { settings } = this.props;
+
+        if (settings.puttingState === 'ERROR') {
+            return <p>Error writing settings: {settings.error.message}</p>;
+        }
+    }
+
     render() {
         const { settings } = this.props;
 
@@ -238,6 +246,7 @@ class SettingsDashboard extends React.Component {
         }
 
         return <div style={this.styles.wrapper}>
+            {this.renderAnyPutError()}
             <Grid container direction="column" alignItems="stretch" justify="space-between" spacing={4} style={{height: '100%'}}>
                 <Grid item style={{height: '50%'}}>
                     <SettingsTable name="Persistent" settings={this.getSettings('persistent')} settingsType='persistent' onEditCell={this.createCellEdit('persistent')} />

--- a/frontend/src/SettingsDashboard.jsx
+++ b/frontend/src/SettingsDashboard.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Button, CircularProgress, IconButton, Grid, TextField, Typography, Modal } from '@material-ui/core';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import AddBoxIcon from '@material-ui/icons/AddBox'
-import { loadSettings, putSetting } from './data/settings/actions';
+import { loadSettings, putSetting, deleteSetting } from './data/settings/actions';
 import { isLoaded, isLoading, isNotLoaded, isErrored } from './data/utils';
 import Table from './Table.js';
 
@@ -12,6 +12,7 @@ const mapStateToProps = ({ clusters, settings }) => ({ clusters, settings });
 const mapDispatchToProps = {
     loadSettings,
     putSetting,
+    deleteSetting,
 }
 
 class SettingsModalInner extends React.Component {
@@ -92,7 +93,7 @@ class SettingsModalInner extends React.Component {
 const SettingsModal = connect(null, mapDispatchToProps)(SettingsModalInner);
 
 
-const SettingsTable = ({ name, settings, settingsType, onEditCell }) => {
+const SettingsTableInner = ({ name, settings, settingsType, onEditCell, deleteSetting }) => {
     const [modalOpen, setModalOpen] = React.useState(false);
     const [modalData, setModalData] = React.useState({});
     const [modalAction, setModalAction] = React.useState('New');
@@ -130,6 +131,7 @@ const SettingsTable = ({ name, settings, settingsType, onEditCell }) => {
                         <Button
                             variant="contained"
                             color="secondary"
+                            onClick={() => deleteSetting(settingsType, data.setting)}
                         >Delete</Button>
                     }
                 />
@@ -190,6 +192,7 @@ const SettingsTable = ({ name, settings, settingsType, onEditCell }) => {
         </Grid>
     </Grid>
 }
+const SettingsTable = connect(null, mapDispatchToProps)(SettingsTableInner);
 
 
 class SettingsDashboard extends React.Component {

--- a/frontend/src/SettingsDashboard.jsx
+++ b/frontend/src/SettingsDashboard.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Button, CircularProgress, IconButton, Grid, TextField, Typography, Modal } from '@material-ui/core';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import AddBoxIcon from '@material-ui/icons/AddBox'
 import { loadSettings, putSetting } from './data/settings/actions';
 import { isLoaded, isLoading, isNotLoaded, isErrored } from './data/utils';
@@ -50,18 +51,19 @@ class NewSettingsModalInner extends React.Component {
                 position: 'absolute',
                 backgroundColor: 'white',
                 padding: 15,
+                width: 800,
             }}>
                 <Grid container direction="column" justify="flex-start" alignItems="flex-start" spacing={4}>
                     <Grid item>
                         <Typography variant="h6">New {this.props.type} setting</Typography>
                     </Grid>
-                    <Grid item>
+                    <Grid item style={{width: '100%'}}>
                         <Grid container direction="row" justify="space-between" alignItems="flex-end">
-                            <Grid item>
-                                <TextField value={this.state.setting} label="Setting" onChange={this.createStateUpdate('setting')} />
+                            <Grid item style={{width: '48%'}}>
+                                <TextField value={this.state.setting} label="Setting" onChange={this.createStateUpdate('setting')} fullWidth={true} />
                             </Grid>
-                            <Grid item>
-                                <TextField value={this.state.value} label="Value" onChange={this.createStateUpdate('value')} />
+                            <Grid item style={{width: '48%'}}>
+                                <TextField value={this.state.value} label="Value" onChange={this.createStateUpdate('value')} fullWidth={true} />
                             </Grid>
                         </Grid>
                     </Grid>
@@ -97,6 +99,29 @@ const SettingsTable = ({ name, settings, settingsType, onEditCell }) => {
         });
     };
 
+    const renderRowEditButton = (data) => {
+        return (
+            <div style={{marginLeft: 15}}>
+                <FormControlLabel
+                    control={
+                        <Button
+                            variant="contained"
+                            color="primary"
+                        >Edit</Button>
+                    }
+                />
+                <FormControlLabel
+                    control={
+                        <Button
+                            variant="contained"
+                            color="secondary"
+                        >Delete</Button>
+                    }
+                />
+            </div>
+        );
+    }
+
     const tableConfig = [
         {
             title: 'Setting',
@@ -104,7 +129,6 @@ const SettingsTable = ({ name, settings, settingsType, onEditCell }) => {
             width: 600,
             searchable: true,
             sortable: true,
-            editable: true,
         },
         {
             title: 'Value',
@@ -112,7 +136,12 @@ const SettingsTable = ({ name, settings, settingsType, onEditCell }) => {
             width: 600,
             searchable: true,
             sortable: true,
-            editable: true,
+        },
+        {
+            title: 'Actions',
+            dataKey: 'value',
+            width: 200,
+            renderFunction: renderRowEditButton,
         },
     ];
 

--- a/frontend/src/Table.js
+++ b/frontend/src/Table.js
@@ -189,6 +189,11 @@ export default class Table extends Component {
     };
 
     cellRenderer = ({ rowIndex, cellData, style, config }) => {
+        if (config.renderFunction) {
+            const rowData = this.getRowData({ index: rowIndex });
+            return config.renderFunction(rowData);
+        }
+
         if (!config.editable) {
             return <TableCell
                 variant="body"

--- a/frontend/src/data/settings/actions.js
+++ b/frontend/src/data/settings/actions.js
@@ -2,9 +2,14 @@ export const SETTING_ACTION_TYPES = {
     LOAD_SETTINGS: 'LOAD_SETTINGS',
     LOAD_SETTINGS_SUCCESS: 'LOAD_SETTINGS_SUCCESS',
     LOAD_SETTINGS_ERROR: 'LOAD_SETTINGS_ERROR',
+
     PUT_SETTING: 'PUT_SETTING',
     PUT_SETTING_SUCCESS: 'PUT_SETTING_SUCCESS',
     PUT_SETTING_ERROR: 'PUT_SETTING_ERROR',
+
+    DELETE_SETTING: 'DELETE_SETTING',
+    DELETE_SETTING_SUCCESS: 'DELETE_SETTING_SUCCESS',
+    DELETE_SETTING_ERROR: 'DELETE_SETTING_ERROR',
 };
 
 export function loadSettings() {
@@ -74,6 +79,47 @@ export function putSetting(settingType, setting, value) {
         } catch (error) {
             dispatch({
                 type: SETTING_ACTION_TYPES.PUT_SETTING_ERROR,
+                error,
+            });
+        }
+    };
+}
+
+export function deleteSetting(settingType, setting) {
+    return async (dispatch, getState) => {
+        const clusterSlug = getState().clusters.currentCluster;
+        if (!clusterSlug) {
+            return;
+        }
+
+        dispatch({
+            type: SETTING_ACTION_TYPES.DELETE_SETTING,
+        });
+
+        try {
+            const response = await fetch(`api/clusters/${clusterSlug}/settings`, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    [settingType]: {
+                        [setting]: null,
+                    },
+                }),
+            });
+            if (response.ok) {
+                dispatch({
+                    type: SETTING_ACTION_TYPES.DELETE_SETTING_SUCCESS,
+                    setting,
+                    settingType,
+                });
+            } else {
+                throw new Error(`Bad response from the server ${response.statusText}`);
+            }
+        } catch (error) {
+            dispatch({
+                type: SETTING_ACTION_TYPES.DELETE_SETTING_ERROR,
                 error,
             });
         }

--- a/frontend/src/data/settings/reducer.js
+++ b/frontend/src/data/settings/reducer.js
@@ -30,6 +30,7 @@ export function reducer(state, action) {
                 loadingState: 'ERROR',
                 error: action.error,
             };
+
         case SETTING_ACTION_TYPES.PUT_SETTING:
             return {
                 ...state,
@@ -37,8 +38,6 @@ export function reducer(state, action) {
                 error: null,
             };
         case SETTING_ACTION_TYPES.PUT_SETTING_SUCCESS:
-            console.log(state, action);
-
             return {
                 ...state,
                 puttingState: 'LOADED',
@@ -54,6 +53,28 @@ export function reducer(state, action) {
             return {
                 ...state,
                 puttingState: 'ERROR',
+                error: action.error,
+            };
+
+        case SETTING_ACTION_TYPES.DELETE_SETTING:
+            return {
+                ...state,
+                deletingState: 'LOADING',
+                error: null,
+            };
+        case SETTING_ACTION_TYPES.DELETE_SETTING_SUCCESS:
+            delete state.data[action.settingType][action.setting];
+            return {
+                ...state,
+                deletingState: 'LOADED',
+                data: {
+                    ...state.data,
+                },
+            };
+        case SETTING_ACTION_TYPES.DELETE_SETTING_ERROR:
+            return {
+                ...state,
+                deletingState: 'ERROR',
                 error: action.error,
             };
         default:


### PR DESCRIPTION
Fixes up the cluster settings page to enable add/edit/delete of both transient/persistent settings via modal.

<img width="1680" alt="Screenshot 2019-12-12 at 11 52 29" src="https://user-images.githubusercontent.com/1026154/70709903-ed1e0200-1cd5-11ea-8231-34d93fdc3822.png">
