### PR TITLE
Make tasks useful

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+frontend/node_modules/
+frontend/build/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ElasticSurgery is an Elastcsearch cluster _management interface_. Designed to vi
 
 ## Development
 
-Setup your environment like so - you'll need [`kubetools-client`](https://github.com/EDITD/kubetools-client) installed:
+Setup your environment like so - you'll need [`kubetools`](https://github.com/EDITD/kubetools) installed:
 
 ```sh
 # Install the node modules

--- a/backend/elasticsurgery/settings.py
+++ b/backend/elasticsurgery/settings.py
@@ -1,8 +1,11 @@
-# TODO: Open-source shouldn't store settings like this.
-SECRET_KEY = '5xP9_fMwqRnF047ZEwnQd9nCLknz3TrdQvggugBMxlo0zT3yEJ0f3g'
-DEBUG = True
+from os import environ
 
-ES_STATE_HOSTS = ['elasticsurgery-elasticsearch:9200']
 
-ES_CLUSTERS_INDEX_NAME = '.elasticsurgery-clusters'
-ES_LOGS_INDEX_NAME = '.elasticsurgery-logs'
+SECRET_KEY = environ.get('SECRET_KEY', 'not-a-secret')
+
+DEBUG = environ.get('DEBUG') == 'on' or environ.get('KTD_ENV')
+
+ES_STATE_HOSTS = environ.get('ES_STATE_HOSTS', 'elasticsurgery-elasticsearch:9200').split(',')
+
+ES_CLUSTERS_INDEX_NAME = environ.get('ES_CLUSTERS_INDEX_NAME', '.elasticsurgery-clusters')
+ES_LOGS_INDEX_NAME = environ.get('ES_LOGS_INDEX_NAME', '.elasticsurgery-logs')

--- a/docker/uwsgi.conf
+++ b/docker/uwsgi.conf
@@ -10,6 +10,7 @@ http-socket = 0.0.0.0:80
 # App
 plugin = python
 module = boot:app
+chdir = backend
 
 # Worker processes
 processes = 4

--- a/frontend/src/TasksDashboard.jsx
+++ b/frontend/src/TasksDashboard.jsx
@@ -188,18 +188,30 @@ class TasksDashboard extends React.Component {
             {
                 title: 'ID',
                 dataKey: 'id',
-                width: 300,
+                width: 100,
                 sortable: true,
             },
             {
                 title: 'Type',
                 dataKey: 'type',
-                width: 300,
+                width: 100,
                 sortable: true,
             },
             {
                 title: 'Action',
                 dataKey: 'action',
+                width: 300,
+                sortable: true,
+            },
+            {
+                title: 'Description',
+                dataKey: 'description',
+                width: 500,
+                sortable: true,
+            },
+            {
+                title: 'Status',
+                dataKey: 'status_string',
                 width: 500,
                 sortable: true,
             },

--- a/frontend/src/TasksDashboard.jsx
+++ b/frontend/src/TasksDashboard.jsx
@@ -5,6 +5,7 @@ import Typography from '@material-ui/core/Typography';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Button from '@material-ui/core/Button';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import TextField from '@material-ui/core/TextField';
 import Checkbox from '@material-ui/core/Checkbox';
 import pretty from 'pretty-time';
 
@@ -30,6 +31,22 @@ const mapStateToProps = ({ tasks, nodes, clusters }) => ({
 const mapDispatchToProps = {
     loadTasks,
     loadNodes,
+};
+
+const filterTaskTableData = (taskDatas, tasksFilter) => {
+    if (!tasksFilter) {
+        return taskDatas;
+    }
+
+    return taskDatas.filter(taskData => {
+        if (taskData.action.indexOf(tasksFilter) > 0) {
+            return true;
+        }
+        if (taskData.type.indexOf(tasksFilter) > 0) {
+            return true;
+        }
+        return false;
+    });
 };
 
 const generateTaskTableData = (taskDatas, includeChildren) => {
@@ -84,6 +101,7 @@ class TasksDashboard extends React.Component {
 
     state = {
         showChildren: false,
+        tasksFilter: '',
     };
 
     componentDidMount() {
@@ -150,28 +168,24 @@ class TasksDashboard extends React.Component {
                 dataKey: 'id',
                 width: 300,
                 sortable: true,
-                searchable: true,
             },
             {
                 title: 'Type',
                 dataKey: 'type',
                 width: 300,
                 sortable: true,
-                searchable: true,
             },
             {
                 title: 'Action',
                 dataKey: 'action',
                 width: 500,
                 sortable: true,
-                searchable: true,
             },
             {
                 title: 'Node',
                 dataKey: 'node',
                 width: 300,
                 sortable: true,
-                searchable: true,
                 formatter: nodeId => {
                     const nodeData = nodes.data.nodes[nodeId];
                     return nodeData ? nodeData.name : nodeId;
@@ -193,7 +207,7 @@ class TasksDashboard extends React.Component {
         ];
 
         const tableData = generateTaskTableData(
-            Object.values(tasks.data.tasks),
+            filterTaskTableData(Object.values(tasks.data.tasks), this.state.tasksFilter),
             this.state.showChildren,
         );
 
@@ -216,6 +230,15 @@ class TasksDashboard extends React.Component {
                         />
                     }
                     label="Show child tasks"
+                />
+                <FormControlLabel
+                    control={
+                        <TextField
+                            value={this.state.tasksFilter}
+                            onChange={(ev) => this.setState({tasksFilter: ev.target.value})}
+                        />
+                    }
+                    label="Filter tasks"
                 />
             </div>
 

--- a/frontend/src/TasksDashboard.jsx
+++ b/frontend/src/TasksDashboard.jsx
@@ -7,6 +7,8 @@ import Button from '@material-ui/core/Button';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import TextField from '@material-ui/core/TextField';
 import Checkbox from '@material-ui/core/Checkbox';
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
 import pretty from 'pretty-time';
 
 import { loadTasks } from './data/tasks/actions';
@@ -102,6 +104,7 @@ class TasksDashboard extends React.Component {
     state = {
         showChildren: false,
         tasksFilter: '',
+        refreshInterval: 0,
     };
 
     componentDidMount() {
@@ -119,10 +122,23 @@ class TasksDashboard extends React.Component {
         }
     }
 
-    componentDidUpdate(prevProps) {
+    componentWillUnmount() {
+        if (this.refreshIntervalTimer) {
+            clearInterval(this.refreshIntervalTimer);
+        }
+    }
+
+    componentDidUpdate(prevProps, prevState) {
         if (prevProps.clusters.currentCluster !== this.props.clusters.currentCluster) {
             this.props.loadNodes();
             this.props.loadTasks();
+        }
+
+        if (prevState.refreshInterval !== this.state.refreshInterval) {
+            this.refreshIntervalTimer = setInterval(
+                this.props.loadTasks,
+                this.state.refreshInterval * 1000,
+            );
         }
     }
 
@@ -214,6 +230,7 @@ class TasksDashboard extends React.Component {
         return <div style={this.getContainerStyles(true)}>
             <div style={this.styles.controls}>
                 <FormControlLabel
+                    style={{marginRight: 40}}
                     control={
                         <Button
                             variant="contained"
@@ -223,6 +240,22 @@ class TasksDashboard extends React.Component {
                     }
                 />
                 <FormControlLabel
+                    style={{marginRight: 20}}
+                    label="Refresh interval"
+                    control={
+                        <Select
+                            value={this.state.refreshInterval}
+                            onChange={(ev) => this.setState({refreshInterval: ev.target.value})}
+                        >
+                            <MenuItem value={0}>Disabled</MenuItem>
+                            <MenuItem value={10}>10s</MenuItem>
+                            <MenuItem value={30}>30s</MenuItem>
+                            <MenuItem value={60}>60s</MenuItem>
+                        </Select>
+                    }
+                />
+                <FormControlLabel
+                    style={{marginRight: 40}}
                     control={
                         <Checkbox
                             value={this.state.showChildren}

--- a/frontend/src/TasksDashboard.jsx
+++ b/frontend/src/TasksDashboard.jsx
@@ -169,12 +169,11 @@ class TasksDashboard extends React.Component {
         });
     };
 
-    render() {
+    renderTable() {
         const { tasks, nodes } = this.props;
+
         if (isNotLoaded(tasks) || isLoading(tasks) || isNotLoaded(nodes) || isLoading(nodes)) {
-            return <div style={this.getContainerStyles()}>
-                <CircularProgress />
-            </div>;
+            return <CircularProgress />;
         }
 
         if (isErrored(tasks) || isErrored(nodes)) {
@@ -234,6 +233,10 @@ class TasksDashboard extends React.Component {
             this.state.showChildren,
         );
 
+        return <Table config={tableConfig} data={tableData} />;
+    }
+
+    render() {
         return <div style={this.getContainerStyles(true)}>
             <div style={this.styles.controls}>
                 <FormControlLabel
@@ -255,6 +258,7 @@ class TasksDashboard extends React.Component {
                             onChange={(ev) => this.setState({refreshInterval: ev.target.value})}
                         >
                             <MenuItem value={0}>Disabled</MenuItem>
+                            <MenuItem value={5}>5s</MenuItem>
                             <MenuItem value={10}>10s</MenuItem>
                             <MenuItem value={30}>30s</MenuItem>
                             <MenuItem value={60}>60s</MenuItem>
@@ -266,6 +270,7 @@ class TasksDashboard extends React.Component {
                     control={
                         <Checkbox
                             value={this.state.showChildren}
+                            checked={this.state.showChildren}
                             onClick={this.toggleShowChildren}
                         />
                     }
@@ -283,7 +288,7 @@ class TasksDashboard extends React.Component {
             </div>
 
             <div style={this.styles.tableWrapper}>
-                <Table config={tableConfig} data={tableData} />
+                {this.renderTable()}
             </div>
         </div>;
     }

--- a/frontend/src/TasksDashboard.jsx
+++ b/frontend/src/TasksDashboard.jsx
@@ -123,9 +123,7 @@ class TasksDashboard extends React.Component {
     }
 
     componentWillUnmount() {
-        if (this.refreshIntervalTimer) {
-            clearInterval(this.refreshIntervalTimer);
-        }
+        this.clearAnyRefreshInterval();
     }
 
     componentDidUpdate(prevProps, prevState) {
@@ -135,10 +133,19 @@ class TasksDashboard extends React.Component {
         }
 
         if (prevState.refreshInterval !== this.state.refreshInterval) {
-            this.refreshIntervalTimer = setInterval(
-                this.props.loadTasks,
-                this.state.refreshInterval * 1000,
-            );
+            this.clearAnyRefreshInterval();
+            if (this.state.refreshInterval) {
+                this.refreshIntervalTimer = setInterval(
+                    this.props.loadTasks,
+                    this.state.refreshInterval * 1000,
+                );
+            }
+        }
+    }
+
+    clearAnyRefreshInterval() {
+        if (this.refreshIntervalTimer) {
+            clearInterval(this.refreshIntervalTimer);
         }
     }
 


### PR DESCRIPTION
Updates the tasks dashboard for auto-refresh, better filter and display. Targetting reindex tasks specifically at the moment, but leaves the door open for pretty status checks for all types:

<img width="1913" alt="Screenshot 2020-06-22 at 13 10 13" src="https://user-images.githubusercontent.com/1026154/85286062-ded14f80-b489-11ea-86b8-3a1be3db4272.png">
